### PR TITLE
Shard testprojects integration tests (#4205)

### DIFF
--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -21,7 +21,7 @@ python_tests(
     'src/python/pants/util:contextutil',
   ],
   tags = {'integration'},
-  timeout=600,
+  timeout=800,
 )
 
 python_library(


### PR DESCRIPTION
### Problem

See #4204: because all tests defined under testprojects are run in a single test method and pytest only outputs anything when a method has completed, travis began failing test runs due to lack of output. Additionally, when this test failed, your only recourse was to run the entire thing.

### Solution

Split the test into "select targets to test" and "test them", and then shard the result N ways on a method-by-method basis. In theory this could have been done bash-wise in `ci.sh`... but frankly, I don't want to grow a bash script if I can avoid it.

### Result

The test is now sharded `N==8` ways.

### Problem

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)